### PR TITLE
DM-21378: Support technote_aastex

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+0.0.4 (2019-09-20)
+==================
+
+This release provides support for ``technote_aastex`` templates, which are prepared similarly to ``technote_latex`` templates.
+
+:jirab:`21378`
+
 0.0.3 (2019-09-11)
 ==================
 

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: templatebotaide-app
-        image: lsstsqre/templatebot-aide:0.0.3
+        image: lsstsqre/templatebot-aide:0.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/templatebotaide/events/handlers/technotepostrender.py
+++ b/templatebotaide/events/handlers/technotepostrender.py
@@ -140,7 +140,7 @@ async def handle_technote_postrender(*, event, schema, app, logger):
                     logger=logger,
                     app=app
                 )
-    elif event['template_name'] == 'technote_latex':
+    elif event['template_name'] in ('technote_latex', 'technote_aastex'):
         # Handle the configuration PR for a LaTeX technote
         try:
             pr_data = await pr_latex_lander_config(

--- a/templatebotaide/events/router.py
+++ b/templatebotaide/events/router.py
@@ -12,7 +12,7 @@ from .handlers import (
     handle_technote_postrender)
 
 
-TECHNOTE_TEMPLATES = ('technote_rst', 'technote_latex')
+TECHNOTE_TEMPLATES = ('technote_rst', 'technote_latex', 'technote_aastex')
 """Names of templates in https://github.com/lsst/templates that correspond to
 technical notes.
 


### PR DESCRIPTION
This`technote_aastex` template is configured just like `technote_latex`, so they can share the same processing paths.