### PR TITLE
DM-25233: Fix technote confirmation message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+0.2.1 (2020-06-06)
+==================
+
+- Fix the confirmation message on technote creation (the multi line string was accidentally turned into a sequence of strings).
+
+- Centralize the image tag version in ``kustomization.yaml``, which is easier to maintain on a release-by-release basis than the deployment YAML.
+
 0.2.0 (2020-06-05)
 ==================
 

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: templatebot-aide-app
-        image: lsstsqre/templatebot-aide:0.1.0
+        image: lsstsqre/templatebot-aide
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -4,3 +4,7 @@ kind: Kustomization
 resources:
   - configmap.yaml
   - deployment.yaml
+
+images:
+  - name: lsstsqre/templatebot-aide
+    newTag: 0.2.1

--- a/templatebotaide/events/handlers/technoteprerender.py
+++ b/templatebotaide/events/handlers/technoteprerender.py
@@ -113,7 +113,7 @@ async def handle_technote_prerender(*, event, schema, app, logger):
             await post_message(
                 text=(
                     "I've set up the technote on _LSST the Docs._ Your "
-                    f"document will appear at {ltd_product['published_url']} ",
+                    f"document will appear at {ltd_product['published_url']} "
                     "in a few minutes after the GitHub Actions build finishes."
                 ),
                 channel=event['slack_channel'],


### PR DESCRIPTION
- Fix the multi-line technote prerender confirmation message.
- Refactor the image version into `kustomization.yaml`, which centralizes it compared to keeping image tags in the deployment YAML.