### PR TITLE
DM-25427: Update to aiokafka 0.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Change log
 ##########
 
+0.3.1 (2020-06-15)
+==================
+
+- Update to kafkit 0.2.0b3.
+
+- Update to aiokafka 0.6.0.
+  This should resolve the issue of unhandled UnknownMemberId exceptions causing consumers to unexpectedly drop their connection to the Kafka brokers.
+
 0.3.0 (2020-06-15)
 ==================
 

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 
 images:
   - name: lsstsqre/templatebot-aide
-    newTag: 0.3.0
+    newTag: 0.3.1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     'click>=6.7,<7.0',
     'fastavro==0.21.16',
     'kafkit==0.1.1',
-    'aiokafka==0.5.2',
+    'aiokafka==0.6.0',
     'gidgethub==3.1.0',
     'cachetools==3.1.0',
     'pycryptodomex==3.8.0',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     'colorama==0.4.1',  # used by structlog
     'click>=6.7,<7.0',
     'fastavro==0.21.16',
-    'kafkit==0.1.1',
+    'kafkit==0.2.0b3',
     'aiokafka==0.6.0',
     'gidgethub==3.1.0',
     'cachetools==3.1.0',


### PR DESCRIPTION
- Update to aiokafka 0.6.0. This should resolve the issue of unhandled UnknownMemberId exceptions causing consumers to unexpectedly drop their connection to the Kafka brokers.

- Update to kafkit 0.2.0b3.