### PR TITLE
DM-25439: Clean user content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Change log
 ##########
 
+0.3.2 (2020-06-16)
+==================
+
+- The pre-render handlers now clean user content:
+
+  - The ``title`` field of documents and technotes no longer contains any line breaks as this isn't compatible with the title's use for a GitHub repository description.
+
+  - The name of a repository no longer contains any whitespace.
+
 0.3.1 (2020-06-15)
 ==================
 

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 
 images:
   - name: lsstsqre/templatebot-aide
-    newTag: 0.3.1
+    newTag: 0.3.2

--- a/templatebotaide/events/handlers/documentprerender.py
+++ b/templatebotaide/events/handlers/documentprerender.py
@@ -9,6 +9,7 @@ import gidgethub
 from templatebotaide.lsstthedocs import register_ltd_product
 from templatebotaide.github import create_repo
 from templatebotaide.slack import post_message, get_user_info
+from templatebotaide.events.handlers.utilities import clean_string_whitespace
 
 
 async def handle_document_prerender(*, event, schema, app, logger):
@@ -33,6 +34,11 @@ async def handle_document_prerender(*, event, schema, app, logger):
     event.
     """
     logger.info('In handle_document_prerender', event_data=event)
+
+    # Clean user input
+    event['variables']['title'] = clean_string_whitespace(
+        event['variables']['title']
+    )
 
     # In the latex_lsstdoc template, the series and serial_number are
     # determined from the handle. This logic attempts to match this metadata

--- a/templatebotaide/events/handlers/genericprerender.py
+++ b/templatebotaide/events/handlers/genericprerender.py
@@ -1,5 +1,6 @@
 __all__ = ('handle_generic_prerender',)
 
+import re
 from copy import deepcopy
 import datetime
 import gidgethub
@@ -35,6 +36,10 @@ async def handle_generic_prerender(*, event, schema, app, logger):
     if event['template_name'] == 'stack_package':
         org_name = event['variables']['github_org']
         repo_name = event['variables']['package_name']
+
+        # Ensure that the repo name has no whitespace
+        repo_name = re.sub(r"\s", "", repo_name)
+        event['variables']['package_name'] = repo_name
     else:
         # Try to work with a general case where github_org and name are the
         # cookiecutter variables for the repo's org and name on GitHub.
@@ -48,6 +53,10 @@ async def handle_generic_prerender(*, event, schema, app, logger):
         except KeyError:
             logger.error('event does not have a variables.name key')
             raise
+
+        # Ensure that the repo name has no whitespace
+        repo_name = re.sub(r"\s", "", repo_name)
+        event['variables']['name'] = repo_name
 
     try:
         repo_info = await create_repo(

--- a/templatebotaide/events/handlers/technoteprerender.py
+++ b/templatebotaide/events/handlers/technoteprerender.py
@@ -8,6 +8,7 @@ import gidgethub
 from templatebotaide.lsstthedocs import register_ltd_product
 from templatebotaide.github import create_repo
 from templatebotaide.slack import post_message, get_user_info
+from templatebotaide.events.handlers.utilities import clean_string_whitespace
 
 
 async def handle_technote_prerender(*, event, schema, app, logger):
@@ -32,6 +33,11 @@ async def handle_technote_prerender(*, event, schema, app, logger):
     event.
     """
     logger.info('In handle_technote_prerender', event_data=event)
+
+    # Clean user input
+    event['variables']['title'] = clean_string_whitespace(
+        event['variables']['title']
+    )
 
     # Get data from the event (user dialog input)
     org_name = event['variables']['github_org']

--- a/templatebotaide/events/handlers/utilities.py
+++ b/templatebotaide/events/handlers/utilities.py
@@ -1,8 +1,9 @@
 """Common handler workflows and other utilities."""
 
-__all__ = ['pr_latex_submodules']
+__all__ = ['pr_latex_submodules', 'clean_string_whitespace']
 
 import asyncio
+import re
 from tempfile import TemporaryDirectory
 from pathlib import Path
 
@@ -99,3 +100,15 @@ async def pr_latex_submodules(*, event, app, logger):
         logger.debug('Finished pushing lsst-texmf PR', branch=new_branch_name)
 
     return pr_response
+
+
+def clean_string_whitespace(text: str) -> str:
+    """Clean whitespace from text that should only be a single paragraph.
+
+    1. Apply ``str.strip`` method
+    2. Apply regular expression substitution of the ``\\s`` whitespace
+       character group with `` `` (a single whitespace).
+    """
+    text = text.strip()
+    text = re.sub(r"\s", " ", text)  # replace all kinds of whitespace
+    return text


### PR DESCRIPTION
The pre-render handlers now clean user content:

  - The ``title`` field of documents and technotes no longer contains any line breaks as this isn't compatible with the title's use for a GitHub repository description.

  - The name of a repository no longer contains any whitespace.
