### PR TITLE
DM-36698: Add ADASS and SPIE templates as technotes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,10 @@
 Change log
 ##########
 
-0.4.1 (unreleased)
+0.5.0 (2022-10-24)
 ==================
 
+- Add technote template pre-rendering support for `ADASS <https://github.com/lsst/templates/tree/main/project_templates/technote_adasstex>`__ and `SPIE <https://github.com/lsst/templates/tree/main/project_templates/technote_spietex>`__ technote templates.
 - Drop support for Python 3.9.
 - Update dependencies.
 

--- a/src/templatebotaide/events/handlers/technotepostrender.py
+++ b/src/templatebotaide/events/handlers/technotepostrender.py
@@ -35,7 +35,13 @@ async def handle_technote_postrender(
     """
     logger.debug("In handle_technote_postrender", event_data=event)
 
-    if event["template_name"] in ("technote_latex", "technote_aastex"):
+    latex_templates = (
+        "technote_latex",
+        "technote_aastex",
+        "technote_adasstex",
+        "technote_spietex",
+    )
+    if event["template_name"] in latex_templates:
         # Handle the configuration PR for a LaTeX technote to add the
         # lsst-texmf submodule.
         try:

--- a/src/templatebotaide/events/router.py
+++ b/src/templatebotaide/events/router.py
@@ -19,7 +19,13 @@ from .handlers import (
 __all__ = ["consume_events"]
 
 
-TECHNOTE_TEMPLATES = ("technote_rst", "technote_latex", "technote_aastex")
+TECHNOTE_TEMPLATES = (
+    "technote_rst",
+    "technote_latex",
+    "technote_aastex",
+    "technote_adasstex",
+    "technote_spietex",
+)
 """Names of templates in https://github.com/lsst/templates that correspond to
 technical notes.
 


### PR DESCRIPTION
This will fire the technote project pre-render hooks before templatebot renders out these new [SPIE](https://github.com/lsst/templates/tree/main/project_templates/technote_spietex) and [ADASS](https://github.com/lsst/templates/tree/main/project_templates/technote_adasstex) technote templates to GitHub.